### PR TITLE
fix: update assertion message when checking for specific exception

### DIFF
--- a/src/FluentAssert.php
+++ b/src/FluentAssert.php
@@ -506,7 +506,7 @@ class FluentAssert extends Assert
         if ($this->exception) {
             $errorWasThrown = true;
             $thrownError = $this->exception;
-        } else {
+        } elseif (is_callable($this->value)) {
             try {
                 $this->value->__invoke();
             } catch (Throwable $error) {

--- a/src/FluentAssert.php
+++ b/src/FluentAssert.php
@@ -538,6 +538,10 @@ class FluentAssert extends Assert
             return new ErroredWithMessageSupplement();
         }
 
+        if (!$errorWasThrown && $class !== null) {
+            self::fail('Expected ' . $class . ' to be thrown, but no exception was thrown.');
+        }
+
         if (!$errorWasThrown) {
             self::fail('Expected an exception to be thrown, but no exception was thrown.');
         }

--- a/tests/ActTest.php
+++ b/tests/ActTest.php
@@ -32,6 +32,7 @@ class ActTest extends TestCase
 
         // ASSERT
         $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Expected Exception to be thrown, but no exception was thrown.');
 
         // ACT
         $result = Act($callback);

--- a/tests/ToThrowTest.php
+++ b/tests/ToThrowTest.php
@@ -83,6 +83,20 @@ class ToThrowTest extends TestCase
     }
 
     #[Test]
+    public function fails_when_expecting_specific_exception_to_be_thrown_but_none_gets_thrown(): void
+    {
+        // ARRANGE
+        $callback = fn () => null;
+
+        // ASSERT
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Expected InvalidArgumentException to be thrown, but no exception was thrown.');
+
+        // ACT
+        Expect($callback)->toThrow(\InvalidArgumentException::class);
+    }
+
+    #[Test]
     public function passes_when_expecting_specific_exception_not_to_be_thrown_and_a_different_exception_gets_thrown(): void
     {
         // ARRANGE


### PR DESCRIPTION
When asserting that a specific exception was thrown and the test was using the Act function the assertion message was incorrect. It now tells you that a specific exception was expected but none was thrown.